### PR TITLE
Refactor: DRY up layouts

### DIFF
--- a/layouts/_base.erb
+++ b/layouts/_base.erb
@@ -1,0 +1,23 @@
+<!DOCTYPE HTML>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Sam Starling</title>
+    <link rel="stylesheet" href="/stylesheet.css">
+    <meta name="generator" content="Nanoc <%= Nanoc::VERSION %>">
+    <meta name='viewport' content='width=device-width, initial-scale=1, maximum-scale=1'>
+    <meta name="google-site-verification" content="H_FiFYlDsR8MHqDJL9fFo06j_h0Wj4gzfTvxrFYTBYg" />
+  </head>
+  <body>
+    <div id="main">
+      <%= yield %>
+    </div>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-109282190-1"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-109282190-1');
+    </script>
+  </body>
+</html>

--- a/layouts/default.html.erb
+++ b/layouts/default.html.erb
@@ -1,23 +1,3 @@
-<!DOCTYPE HTML>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <title>Sam Starling</title>
-    <link rel="stylesheet" href="/stylesheet.css">
-    <meta name="generator" content="Nanoc <%= Nanoc::VERSION %>">
-    <meta name='viewport' content='width=device-width, initial-scale=1, maximum-scale=1'>
-    <meta name="google-site-verification" content="H_FiFYlDsR8MHqDJL9fFo06j_h0Wj4gzfTvxrFYTBYg" />
-  </head>
-  <body>
-    <div id="main">
-      <%= yield %>
-    </div>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-109282190-1"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'UA-109282190-1');
-    </script>
-  </body>
-</html>
+<% render '/_base.*' do %>
+  <%= yield %>
+<% end %>

--- a/layouts/post.html.erb
+++ b/layouts/post.html.erb
@@ -1,28 +1,8 @@
-<!DOCTYPE HTML>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <title><%= item[:title] %> &middot; Sam Starling</title>
-    <link rel="stylesheet" href="/stylesheet.css">
-    <meta name="generator" content="Nanoc <%= Nanoc::VERSION %>">
-    <meta name='viewport' content='width=device-width, initial-scale=1, maximum-scale=1'>
-    <meta name="google-site-verification" content="H_FiFYlDsR8MHqDJL9fFo06j_h0Wj4gzfTvxrFYTBYg" />
-  </head>
-  <body>
-    <div id="main">
-      <p><a href="/">&larr; Home</a></p>
-      <div class="PostHeading">
-        <h1 class="PostHeading--title"><%= item[:title] %></h1>
-        <div class="PostHeading--date"><%= friendly_date_for(item) %></div>
-      </div>
-      <%= yield %>
-      <script async src="https://www.googletagmanager.com/gtag/js?id=UA-109282190-1"></script>
-      <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-        gtag('config', 'UA-109282190-1');
-      </script>
-    </div>
-  </body>
-</html>
+<% render '/_base.*' do %>
+  <p><a href="/">&larr; Home</a></p>
+  <div class="PostHeading">
+    <h1 class="PostHeading--title"><%= item[:title] %></h1>
+    <div class="PostHeading--date"><%= friendly_date_for(item) %></div>
+  </div>
+  <%= yield %>
+<% end %>


### PR DESCRIPTION
This extracts common content from both layouts into a new `_base` layout, which is now called from both layouts.

Alternative approach: don’t call `render '/_base.*'` but instead, have two `layout` calls in the `Rules` file (one for `layout '/default.*'` and one for `layout '/_base.*'`).